### PR TITLE
Load js module

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ Matching rules can match anything that is in the module object, which includes `
 
 ### Examples
 
+
+There is code for an example you can take a look [here](https://github.com/MiguelCastillo/bit-bundler-splitter/tree/master/examples/renderer).  You can run it with:
+
+```
+$ npm install
+$ npm run build
+$ cat dist/vendor.js dist/renderer.js dist/main.js | node
+```
+
+
+Below are other examples to help illustrate how you can use matching rules.
+
 Let's take a look at a setup that matches any module name that only has alpha numeric characters. e.g. "jquery".
 
 ``` javascript

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 This plugin helps slice and dice your application bundle into smaller bundles which we refer to as bundle shards. The more common use case is to split out the vendor (3rd party) modules into a separate bundle. This is to maximize browsers' caching capabilities; generally speaking vendor bundles do not change frequently and browsers can cache them rather efficiently. Vendor bundles also tend to be larger than your more frequently changing application bundles, which generally translates to a reduction in traffic when properly cached by the browser.
 
+Bundle splitting works by defining matching rules for the modules you want in a separate bundle. Any module that matches the rules becomes a bundle or added to already existing bundles. You can match modules with regexes on the filepath, or any other piece of information available on them. The modules that are split into its own bundle actually bring its entire dependency tree, unless of course a dependency matches a rule in which case the dependency becomes its own bundle. What bundle splitter ends up with is a tree of bundles with the corresponding modules that matched splitting rules at each node. And all corresponding module dependencies are tucked into each of the corresponding bundles.
+
+Once all bundles are created, a special bundle called `loader` is created and saved as `loader.js`. This bundle is special in that it will contain the necessary information to automatically load all the bundles in the correct order in the browser. You can use this file in your index HTML to automatically load all the bundles in the correct order. Or you can choose to load the bundles however way you want.
+
 `bit-bundler-splitter` uses [roolio](https://github.com/MiguelCastillo/roolio) to provide a flexible way to configure matching rules that control how bundles are split. More on this in the examples section.
 
 ### Install
@@ -15,7 +19,9 @@ $ npm install --save-dev bit-bundler-splitter
 
 ### example
 
-This example shows a basic `bit-bundler` setup with `bit-bundler-splitter` splitting out vendor bundles by matching the path of module. If the module path contains `bower_components` or `node_modules` then it is considered a 3rd party library and it gets push to the vendor bundle. We are also splitting out modules whose path contains `src/renderer` and writing that out as a separate bundle.
+This example shows a basic `bit-bundler` setup with `bit-bundler-splitter` splitting out vendor bundles by matching module paths. If the module path contains `bower_components` or `node_modules` then it is considered a 3rd party library and it gets push to the vendor bundle. We are also splitting out modules whose path contains `src/renderer` and writing that out as a separate bundle.
+
+You can see this example at [https://bundler.bitjs.io/Examples.html#how-about-bundle-splitting](bit-bundler's page).
 
 > `bit-bundler-splitter` splits out vendor modules by default when no matching rules are defined.
 
@@ -41,9 +47,9 @@ Bitbundler.bundle({
 
 ### API
 
-#### splitBundle( options: object )
+#### splitBundle( config: object )
 
-`bit-bundler-splitter` exports a function that we generally call `splitBundle`.
+`bit-bundler-splitter` exports a function that takes the following configuration.
 
 - @param {object} options - Configuration options explained below.
   - `match`, matching rules which is how we configure how bundles are split.

--- a/examples/renderer/.bitbundler.js
+++ b/examples/renderer/.bitbundler.js
@@ -1,0 +1,16 @@
+module.exports = {
+  src: "src/main.js",
+  dest: "dist/main.js",
+  multiprocess: 2,
+
+  loader: [
+    "bit-loader-babel"
+  ],
+
+  bundler: [
+    ["bit-bundler-splitter", [
+      { name: "vendor", dest: "dist/vendor.js", match: { path: /\/node_modules\// } },
+      { name: "renderer", dest: "dist/renderer.js", match: { path: /\/src\/renderer\// } }
+    ]]
+  ]
+};

--- a/examples/renderer/package.json
+++ b/examples/renderer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "examples",
+  "version": "1.0.0",
+  "description": "bit-bundler examples",
+  "main": "basic.js",
+  "scripts": {
+    "build": "bitbundler",
+    "analyze": "source-map-explorer dist/main.js && source-map-explorer dist/renderer.js && source-map-explorer dist/vendor.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Miguel Castillo <manchagnu@gmail.com>",
+  "license": "MIT",
+  "dependencies": {
+    "bit-loader-babel": "^2.0.0",
+    "log2console": "^1.0.3"
+  },
+  "devDependencies": {
+    "bit-bundler": "latest",
+    "bit-bundler-splitter": "latest",
+    "source-map-explorer": "^1.3.3"
+  }
+}

--- a/examples/renderer/src/main.js
+++ b/examples/renderer/src/main.js
@@ -1,0 +1,15 @@
+import Other from './other';
+import log2console from 'log2console';
+
+class Main {
+  constructor() {
+    this._other = new Other();
+  }
+
+  render() {
+    log2console(`render:main`);
+    this._other.render();
+  }
+}
+
+(new Main()).render();

--- a/examples/renderer/src/other.js
+++ b/examples/renderer/src/other.js
@@ -1,0 +1,17 @@
+import RenderIt from './renderer/render-it';
+import mainRecursive from './main';
+import log2console from 'log2console';
+
+class Other extends RenderIt {
+  constructor() {
+    super();
+  }
+
+  render() {
+    super.render();
+    log2console(`render:other`);
+    log2console('test recursive', mainRecursive);
+  }
+}
+
+export default Other;

--- a/examples/renderer/src/renderer/render-it.js
+++ b/examples/renderer/src/renderer/render-it.js
@@ -1,0 +1,12 @@
+import log2console from 'log2console';
+
+class RenderIt {
+  constructor() {
+  }
+
+  render() {
+    log2console('base render-it!');
+  }
+}
+
+export default RenderIt;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const Splitter = require("./src/splitter");
 const path = require("path");
 const loaderJS = require("fs").readFileSync(path.join(__dirname, "loader.js"));
 
-
 function createSplitter(options) {
   return new Splitter(options);
 }
@@ -53,9 +52,9 @@ function buildShardLoader(splitData) {
   const shardPaths = splitData.shardLoadOrder
     .map(shardName => context.getBundles(shardName).dest)
     .filter(dest => dest && typeof dest === "string")
-    .map(shardPath => `"${path.relative(path.dirname(loaderPath), shardPath)}"`);
+    .map(shardPath => `"./${path.relative(path.dirname(loaderPath), shardPath)}"`);
 
-  const loadEntries = loaderJS + `;loadJS([${shardPaths}]);`;
+  const loadEntries = `(function(){\n${loaderJS}\n;load([${shardPaths}]);\n})();`;
   return context.setBundle({ name: "loader", content: loadEntries, dest: loaderPath });
 }
 

--- a/loader.js
+++ b/loader.js
@@ -1,132 +1,39 @@
-(function(global, factory) {
-  if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
-    // CommonJS support
-    module.exports = factory();
-  } else if (typeof define === "function" && define.amd) {
-    // Do AMD support
-    define(["loadJS"], factory);
-  } else {
-    // Do browser support
-    global.loadJS = factory();
-  }
-})(this, function() {
-  var cache = {};
-  var head = document.getElementsByTagName("head")[0] || document.documentElement;
+var head = document.getElementsByTagName("head")[0] || document.documentElement;
 
-  function exec(options) {
-    if (typeof options === "string") {
-      options = {
-        url: options
-      };
+function loadScript(head, script) {
+  // Handle Script loading
+  var done = false;
+
+  // Attach handlers for all browsers.
+  //
+  // References:
+  // http://stackoverflow.com/questions/4845762/onload-handler-for-script-tag-in-internet-explorer
+  // http://stevesouders.com/efws/script-onload.php
+  // https://www.html5rocks.com/en/tutorials/speed/script-loading/
+  //
+  script.onload = script.onreadystatechange = function() {
+    if (!done && (!script.readyState || script.readyState === "loaded" || script.readyState === "complete")) {
+      done = true;
+
+      // Handle memory leak in IE
+      script.onload = script.onreadystatechange = null;
     }
-
-    var cacheId = options.id || options.url;
-    var cacheEntry = cache[cacheId];
-
-    if (cacheEntry) {
-      console.log("load-js: cache hit", cacheId);
-      return cacheEntry;
-    }
-    else if (options.allowExternal !== false) {
-      var el = getScriptById(options.id) || getScriptByUrl(options.url);
-
-      if (el) {
-        var promise = Promise.resolve(el);
-
-        if (cacheId) {
-          cache[cacheId] = promise;
-        }
-
-        return promise;
-      }
-    }
-
-    if (!options.url && !options.text) {
-      throw new Error("load-js: must provide a url or text to load");
-    }
-
-    var pending = (options.url ? loadScript : runScript)(head, createScript(options));
-
-    if (cacheId && options.cache !== false) {
-      cache[cacheId] = pending;
-    }
-
-    return pending;
-  }
-
-  function runScript(head, script) {
-    head.appendChild(script);
-    return Promise.resolve(script);
-  }
-
-  function loadScript(head, script) {
-    return new Promise(function(resolve, reject) {
-      // Handle Script loading
-      var done = false;
-
-      // Attach handlers for all browsers.
-      //
-      // References:
-      // http://stackoverflow.com/questions/4845762/onload-handler-for-script-tag-in-internet-explorer
-      // http://stevesouders.com/efws/script-onload.php
-      // https://www.html5rocks.com/en/tutorials/speed/script-loading/
-      //
-      script.onload = script.onreadystatechange = function() {
-        if (!done && (!script.readyState || script.readyState === "loaded" || script.readyState === "complete")) {
-          done = true;
-
-          // Handle memory leak in IE
-          script.onload = script.onreadystatechange = null;
-          resolve(script);
-        }
-      };
-
-      script.onerror = reject;
-
-      head.appendChild(script);
-    });
-  }
-
-  function createScript(options) {
-    var script = document.createElement("script");
-    script.charset = options.charset || "utf-8";
-    script.type = options.type || "text/javascript";
-    script.async = !!options.async;
-    script.id = options.id || options.url;
-    script.loadJS = "watermark";
-
-    if (options.url) {
-      script.src = options.url;
-    }
-
-    if (options.text) {
-      script.text = options.text;
-    }
-
-    return script;
-  }
-
-  function getScriptById(id) {
-    var script = id && document.getElementById(id);
-
-    if (script && script.loadJS !== "watermark") {
-      console.warn("load-js: duplicate script with id:", id);
-      return script;
-    }
-  }
-
-  function getScriptByUrl(url) {
-    var script = url && document.querySelector("script[src='" + url + "']");
-
-    if (script && script.loadJS !== "watermark") {
-      console.warn("load-js: duplicate script with url:", url);
-      return script;
-    }
-  }
-
-  return function load(items) {
-    return items instanceof Array ?
-      Promise.all(items.map(exec)) :
-      exec(items);
   };
-});
+
+  head.appendChild(script);
+}
+
+function createScript(url) {
+  var script = document.createElement("script");
+  script.charset = "utf-8";
+  script.type = "text/javascript";
+  script.async = false;
+  script.src = url;
+  return script;
+}
+
+function load(urls) {
+  urls.forEach(function(url) {
+    loadScript(head, createScript(url));
+  });
+}


### PR DESCRIPTION
This PR cleans up a lot of unused code in loader.js that was leftover from copying `load-js`. This PR also includes a example that you can take a look to illustrate and play around with bundle splitting.