### PR TITLE
fixed issue where shards that have already been processed would miss …

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
     "babel-core": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0",
+    "belty": "^5.2.1",
     "bit-bundler": "^11.0.0",
     "bit-loader-builtins": "^2.0.2",
     "chai": "^4.1.2",
     "eslint": "^4.16.0",
     "log2console": "^1.0.3",
-    "mocha": "^5.0.0"
+    "mocha": "^5.0.0",
+    "spromise": "^1.0.0"
   }
 }

--- a/src/shard/nodeBuilder.js
+++ b/src/shard/nodeBuilder.js
@@ -51,7 +51,7 @@ module.exports = function nodeBuilder(moduleCache, splitters, shardRepository) {
     var currentNode = shardRepository.getShard(info.name);
     var moduleIndex = 0, moduleIdList = info.entries.slice(0);     
     var currentModule, newNode, nodeUpdate;
-    var result = {};
+    var splitPoints = {};
 
     for (moduleIndex = 0; moduleIdList.length !== moduleIndex; moduleIndex++) {
       currentModule = moduleCache[moduleIdList[moduleIndex]];
@@ -84,11 +84,11 @@ module.exports = function nodeBuilder(moduleCache, splitters, shardRepository) {
         moduleIdList[moduleIndex] = null;
         shardRepository.setShard(newNode.addEntries(currentModule.id));
 
-        if (!result[newNode.name]) {
-          result[newNode.name] = { entries: [] };
+        if (!splitPoints[newNode.name]) {
+          splitPoints[newNode.name] = { entries: [] };
         }
 
-        result[newNode.name].entries.push(currentModule.id);
+        splitPoints[newNode.name].entries.push(currentModule.id);
       }
       else {
         moduleIdList = moduleIdList.concat(currentModule.deps.map(dep => dep.id));
@@ -98,7 +98,7 @@ module.exports = function nodeBuilder(moduleCache, splitters, shardRepository) {
 
     shardRepository.setShard(currentNode.addModules(moduleIdList.filter(Boolean)));
 
-    return result;
+    return splitPoints;
   }
 
   return {

--- a/src/shard/treeBuilder.js
+++ b/src/shard/treeBuilder.js
@@ -8,12 +8,12 @@ function treeBuilder(moduleCache, splitters, shardRepository) {
 
     const nodeBuilder = createNodeBuilder(moduleCache, splitters, shardRepository);
     var shardList = [{ name: rootShardName, entries: rootModuleIds }];
-    var result;
+    var splitPoints;
 
     for (var shardIndex = 0; shardList.length !== shardIndex; shardIndex++) {
-      result = nodeBuilder.buildNode(shardList[shardIndex]);
-      result = Object.keys(result).map(key => ({ name: key, entries: result[key].entries }));
-      shardList = shardList.concat(result);
+      splitPoints = nodeBuilder.buildNode(shardList[shardIndex]);
+      splitPoints = Object.keys(splitPoints).map(key => ({ name: key, entries: splitPoints[key].entries }));
+      shardList = shardList.concat(splitPoints);
     }
 
     return nodeBuilder.getStats();

--- a/src/shard/treeBuilder.js
+++ b/src/shard/treeBuilder.js
@@ -7,17 +7,13 @@ function treeBuilder(moduleCache, splitters, shardRepository) {
     shardRepository.setShard({ name: rootShardName, entries: rootModuleIds });
 
     const nodeBuilder = createNodeBuilder(moduleCache, splitters, shardRepository);
-    const visitedShards = {};
-    var shardList = [rootShardName];
-    var currentShard;
+    var shardList = [{ name: rootShardName, entries: rootModuleIds }];
+    var result;
 
     for (var shardIndex = 0; shardList.length !== shardIndex; shardIndex++) {
-      if (!visitedShards[shardList[shardIndex]]) {
-        visitedShards[shardList[shardIndex]] = true;
-        nodeBuilder.buildNode(shardList[shardIndex]);
-        currentShard = shardRepository.getShard(shardList[shardIndex]);
-        shardList = shardList.concat(currentShard.children);
-      }
+      result = nodeBuilder.buildNode(shardList[shardIndex]);
+      result = Object.keys(result).map(key => ({ name: key, entries: result[key].entries }));
+      shardList = shardList.concat(result);
     }
 
     return nodeBuilder.getStats();

--- a/test/package.json
+++ b/test/package.json
@@ -9,7 +9,10 @@
   "author": "Miguel Castillo <manchagnu@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "belty": "^5.2.1",
     "bit-loader-builtins": "^2.0.0",
-    "log2console": "^1.0.3"
-  }
+    "log2console": "^1.0.3",
+    "spromise": "^1.0.0"
+  },
+  "devDependencies": {}
 }

--- a/test/sample/basic/Y.js
+++ b/test/sample/basic/Y.js
@@ -1,5 +1,5 @@
 /*eslint no-console: ["off"]*/
-const path = require("path");
+const log2console = require("log2console");
 const z = require("./z");
 const X = require("./X");
 

--- a/test/sample/basic/c.js
+++ b/test/sample/basic/c.js
@@ -1,2 +1,3 @@
+require("spromise");
 require("./w");
 module.exports = require("./Y");

--- a/test/sample/basic/w.js
+++ b/test/sample/basic/w.js
@@ -1,2 +1,2 @@
 module.exports = require("./X");
-const path = require("path");
+const log2console = require("log2console");

--- a/test/sample/basic/z.js
+++ b/test/sample/basic/z.js
@@ -1,4 +1,6 @@
 /*eslint no-console: ["off"]*/
+require("belty");
+
 module.exports = function() {
   return {
     roast: "this",

--- a/test/spec/index.js
+++ b/test/spec/index.js
@@ -17,11 +17,11 @@ describe("BitBundler test suite", function() {
         bundler: [
           bundleSplitter([
             // { name: "test/dist/X.js", match: { fileName: "X.js" }},
+            { name: "test/dist/basic/deep/vendor.js", match: ["/node_modules/"] },
             { name: "test/dist/basic/c.js", match: /c.js$/ },
             { name: "test/dist/basic/W.js", match: /w.js$/ },
             { name: "test/dist/basic/Y.js", match: "basic/Y.js" },
-            { name: "test/dist/basic/deep/Z.js", match: { filename: "z.js" }},
-            { name: "test/dist/basic/deep/vendor.js", match: ["/node_modules/"] }
+            { name: "test/dist/basic/deep/Z.js", match: { filename: "z.js" }}
           ])
         ]
       });
@@ -104,6 +104,10 @@ describe("BitBundler test suite", function() {
 
       it("then splitter created a shard for 'test/dist/basic/deep/Z.js'", function() {
         expect(result.shards).to.have.property("test/dist/basic/deep/Z.js");
+      });
+
+      it("then the 'vendor' bundle has 27 modules", function() {
+        expect(result.shards["test/dist/basic/deep/vendor.js"].modules).to.have.lengthOf(27);
       });
     });
   });


### PR DESCRIPTION
…further matches

Given the following hierarchy of matches.

shard A
  vendor match
shard vendor
shard B
  vendor match

The sequence of matches above is that shard A has a vendor module and so does shard B. If the vendor shard get processed before shard B then vendor modules in shard B would not make it to the vendor shard.